### PR TITLE
Fix item page navigation using History API

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import ItemsList from "./pages/ItemsList";
 import ItemDetail from "./pages/ItemDetail";
 import CreateItem from "./pages/CreateItem";
 import EditItem from "./pages/EditItem";
+import { navigate } from "./navigation";
 
 function Header() {
   return (
@@ -27,13 +28,37 @@ function Sidebar() {
       <nav>
         <ul>
           <li>
-            <a href="/">Dashboard</a>
+            <a
+              href="/"
+              onClick={e => {
+                e.preventDefault();
+                navigate("/");
+              }}
+            >
+              Dashboard
+            </a>
           </li>
           <li>
-            <a href="/items">Items</a>
+            <a
+              href="/items"
+              onClick={e => {
+                e.preventDefault();
+                navigate("/items");
+              }}
+            >
+              Items
+            </a>
           </li>
           <li>
-            <a href="#">Settings</a>
+            <a
+              href="/settings"
+              onClick={e => {
+                e.preventDefault();
+                navigate("/settings");
+              }}
+            >
+              Settings
+            </a>
           </li>
         </ul>
       </nav>
@@ -42,12 +67,12 @@ function Sidebar() {
 }
 
 function App() {
-  const [route, setRoute] = useState(window.location.hash);
+  const [route, setRoute] = useState(window.location.pathname);
 
   useEffect(() => {
-    const onHashChange = () => setRoute(window.location.hash);
-    window.addEventListener("hashchange", onHashChange);
-    return () => window.removeEventListener("hashchange", onHashChange);
+    const onLocationChange = () => setRoute(window.location.pathname);
+    window.addEventListener("popstate", onLocationChange);
+    return () => window.removeEventListener("popstate", onLocationChange);
   }, []);
 
   const renderRoute = () => {

--- a/client/src/navigation.js
+++ b/client/src/navigation.js
@@ -1,0 +1,4 @@
+export function navigate(to) {
+  window.history.pushState({}, '', to);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}

--- a/client/src/pages/CreateItem.jsx
+++ b/client/src/pages/CreateItem.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { navigate } from "../navigation";
 
 const API_URL = "http://localhost:5000/items";
 
@@ -12,7 +13,7 @@ export default function CreateItem() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name })
     });
-    window.location.hash = "#/items";
+    navigate("/items");
   };
 
   return (

--- a/client/src/pages/EditItem.jsx
+++ b/client/src/pages/EditItem.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { navigate } from "../navigation";
 
 const API_URL = "http://localhost:5000/items";
 
@@ -23,7 +24,7 @@ export default function EditItem({ id }) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name }),
     });
-    window.location.hash = `/items/${id}`;
+    navigate(`/items/${id}`);
   };
 
   if (loading) return <p>Loading...</p>;

--- a/client/src/pages/ItemDetail.jsx
+++ b/client/src/pages/ItemDetail.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { navigate } from "../navigation";
 
 const API_URL = "http://localhost:5000/items";
 
@@ -22,8 +23,24 @@ export default function ItemDetail({ id }) {
   return (
     <div>
       <h2>{item.name}</h2>
-      <a href={`/items/${id}/edit`}>Edit</a>
-      <a href="/items">Back to list</a>
+      <a
+        href={`/items/${id}/edit`}
+        onClick={e => {
+          e.preventDefault();
+          navigate(`/items/${id}/edit`);
+        }}
+      >
+        Edit
+      </a>
+      <a
+        href="/items"
+        onClick={e => {
+          e.preventDefault();
+          navigate("/items");
+        }}
+      >
+        Back to list
+      </a>
     </div>
   );
 }

--- a/client/src/pages/ItemsList.jsx
+++ b/client/src/pages/ItemsList.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { navigate } from "../navigation";
 
 const API_URL = "http://localhost:5000/items";
 
@@ -26,12 +27,36 @@ export default function ItemsList() {
   return (
     <div>
       <h2>Items</h2>
-      <a href="/items/new">Create Item</a>
+      <a
+        href="/items/new"
+        onClick={e => {
+          e.preventDefault();
+          navigate("/items/new");
+        }}
+      >
+        Create Item
+      </a>
       <ul>
         {items.map(item => (
           <li key={item._id}>
-            <a href={`/items/${item._id}`}>{item.name}</a>{" "}
-            <a href={`/items/${item._id}/edit`}>Edit</a>{" "}
+            <a
+              href={`/items/${item._id}`}
+              onClick={e => {
+                e.preventDefault();
+                navigate(`/items/${item._id}`);
+              }}
+            >
+              {item.name}
+            </a>{" "}
+            <a
+              href={`/items/${item._id}/edit`}
+              onClick={e => {
+                e.preventDefault();
+                navigate(`/items/${item._id}/edit`);
+              }}
+            >
+              Edit
+            </a>{" "}
             <button onClick={() => deleteItem(item._id)}>Delete</button>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- replace hash-based routing with History API state and popstate listener
- add navigation helper and update sidebar and item pages to use it

## Testing
- `npm test` (root) *(fails: Missing script)*
- `npm test` (client) *(fails: Missing script)*
- `npm run lint` (client)
- `npm test` (server) *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688ef054be9c8329be97033b0b34315f