### PR TITLE
Add navigation bar and reference lookup page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import ItemsList from "./pages/ItemsList";
 import ItemDetail from "./pages/ItemDetail";
 import CreateItem from "./pages/CreateItem";
 import EditItem from "./pages/EditItem";
+import Reference from "./pages/Reference";
 
 function Header() {
   return (
@@ -27,17 +28,41 @@ function Sidebar() {
       <nav>
         <ul>
           <li>
-            <a href="/">Dashboard</a>
+            <a href="#/">Dashboard</a>
           </li>
           <li>
-            <a href="/items">Items</a>
+            <a href="#/items">Items</a>
           </li>
           <li>
-            <a href="#">Settings</a>
+            <a href="#/settings">Settings</a>
           </li>
         </ul>
       </nav>
     </aside>
+  );
+}
+
+function NavBar() {
+  return (
+    <nav className="app-nav">
+      <ul>
+        <li>
+          <a href="#/">Home</a>
+        </li>
+        <li>
+          <a href="#/reference">Reference</a>
+        </li>
+        <li>
+          <a href="#/items">Inventory</a>
+        </li>
+        <li>
+          <a href="#/reactions">Reactions</a>
+        </li>
+        <li>
+          <a href="#/experiments">Experiments</a>
+        </li>
+      </ul>
+    </nav>
   );
 }
 
@@ -51,16 +76,28 @@ function App() {
   }, []);
 
   const renderRoute = () => {
-    if (route.startsWith("/items/") && route.endsWith("/edit")) {
+    if (route.startsWith("#/items/") && route.endsWith("/edit")) {
       const id = route.split("/")[2];
       return <EditItem id={id} />;
     }
-    if (route === "/items/new") {
+    if (route === "#/items/new") {
       return <CreateItem />;
     }
-    if (route.startsWith("/items/") && route.split("/").length === 3) {
+    if (route.startsWith("#/items/") && route.split("/").length === 3) {
       const id = route.split("/")[2];
       return <ItemDetail id={id} />;
+    }
+    if (route === "#/reference") {
+      return <Reference />;
+    }
+    if (
+      route === "#/items" ||
+      route === "#/inventory" ||
+      route === "#/" ||
+      route === "" ||
+      route === "#"
+    ) {
+      return <ItemsList />;
     }
     return <ItemsList />;
   };
@@ -68,6 +105,7 @@ function App() {
   return (
     <div className="app-container">
       <Header />
+      <NavBar />
       <div className="app-body">
         <Sidebar />
         <main className="app-content">{renderRoute()}</main>

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -28,6 +28,31 @@ body, html, #root {
     text-align: center;
   }
 
+  .app-nav {
+    background-color: $blue-mid;
+    padding: 0.5rem 1rem;
+
+    ul {
+      list-style: none;
+      display: flex;
+      margin: 0;
+      padding: 0;
+
+      li {
+        margin-right: 1rem;
+
+        a {
+          color: $text-light;
+          text-decoration: none;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+  }
+
   .app-body {
     display: flex;
     flex: 1;

--- a/client/src/pages/Reference.jsx
+++ b/client/src/pages/Reference.jsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+export default function Reference() {
+  const [name, setName] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    // Example API call placeholder:
+    // const response = await fetch(`/api/chemicals?name=${encodeURIComponent(name)}`);
+    // const data = await response.json();
+    // console.log(data);
+  };
+
+  return (
+    <div>
+      <h2>Chemical Reference</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Chemical name"
+        />
+        <button type="submit">Lookup</button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/pages/Reference.jsx
+++ b/client/src/pages/Reference.jsx
@@ -2,13 +2,13 @@ import { useState } from "react";
 
 export default function Reference() {
   const [name, setName] = useState("");
+  const pubchem = "https://pubchem.ncbi.nlm.nih.gov/rest/pug/";
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async e => {
     e.preventDefault();
-    // Example API call placeholder:
-    // const response = await fetch(`/api/chemicals?name=${encodeURIComponent(name)}`);
-    // const data = await response.json();
-    // console.log(data);
+    const response = await fetch(`${pubchem}/compound/name/${name}/JSON`);
+    const data = await response.json();
+    console.log(data);
   };
 
   return (
@@ -17,7 +17,7 @@ export default function Reference() {
       <form onSubmit={handleSubmit}>
         <input
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={e => setName(e.target.value)}
           placeholder="Chemical name"
         />
         <button type="submit">Lookup</button>


### PR DESCRIPTION
## Summary
- Add navigation bar with links to Home, Reference, Inventory, Reactions, and Experiments
- Create Reference page with a chemical name lookup form and API call placeholder
- Support hash-based routing for the new navigation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ef1909a988329bf49d3240da70ec2