### PR TITLE
Add chemical inventory type with PubChem lookup

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,9 @@ import EditPPE from "./pages/ppe/EditPPE";
 import EquipmentDetail from "./pages/equipment/EquipmentDetail";
 import CreateEquipment from "./pages/equipment/CreateEquipment";
 import EditEquipment from "./pages/equipment/EditEquipment";
+import ChemicalDetail from "./pages/chemicals/ChemicalDetail";
+import CreateChemical from "./pages/chemicals/CreateChemical";
+import EditChemical from "./pages/chemicals/EditChemical";
 import Reference from "./pages/Reference";
 
 function Header() {
@@ -87,6 +90,9 @@ function App() {
             <Route path="/equipment/new" element={<CreateEquipment />} />
             <Route path="/equipment/:id" element={<EquipmentDetail />} />
             <Route path="/equipment/:id/edit" element={<EditEquipment />} />
+            <Route path="/chemicals/new" element={<CreateChemical />} />
+            <Route path="/chemicals/:id" element={<ChemicalDetail />} />
+            <Route path="/chemicals/:id/edit" element={<EditChemical />} />
             <Route path="/reference" element={<Reference />} />
             <Route path="*" element={<Navigate to="/inventory" replace />} />
           </Routes>

--- a/client/src/pages/Inventory.jsx
+++ b/client/src/pages/Inventory.jsx
@@ -3,12 +3,14 @@ import { Link, useSearchParams } from "react-router-dom";
 import "./glassware/Glassware.scss";
 import "./ppe/PPE.scss";
 import "./equipment/Equipment.scss";
+import "./chemicals/Chemical.scss";
 
 const API_URLS = {
   all: "/api/inventory",
   glassware: "/api/glassware",
   ppe: "/api/ppe",
   equipment: "/api/equipment",
+  chemicals: "/api/chemicals",
 };
 
 export default function Inventory() {
@@ -50,25 +52,37 @@ export default function Inventory() {
       {type === "glassware" && <Link to="/glassware/new">Add Glassware</Link>}
       {type === "ppe" && <Link to="/ppe/new">Add PPE</Link>}
       {type === "equipment" && <Link to="/equipment/new">Add Equipment</Link>}
+      {type === "chemicals" && <Link to="/chemicals/new">Add Chemical</Link>}
       {type === "all" && (
         <>
           <Link to="/glassware/new">Add Glassware</Link> <br />
           <Link to="/ppe/new">Add PPE</Link> <br />
-          <Link to="/equipment/new">Add Equipment</Link>
+          <Link to="/equipment/new">Add Equipment</Link> <br />
+          <Link to="/chemicals/new">Add Chemical</Link>
         </>
       )}
       <ul className={(type === "all" ? "glassware" : type) + "-list"}>
-        {items.map(g => {
-          const itemType = type === "all" ? g.type : type;
+        {items.map(item => {
+          const itemType = type === "all" ? item.type : type;
           return (
-            <li key={g._id}>
-              <Link to={`/${itemType}/${g._id}`}>
-                {g.brand} {g.category}
-                {itemType === "glassware" && ` (${g.capacity} mL)`}
+            <li key={item._id}>
+              <Link to={`/${itemType}/${item._id}`}>
+                {itemType === "chemicals"
+                  ? item.name
+                  : `${item.brand} ${item.category}`} 
+                {itemType === "glassware" && ` (${item.capacity} mL)`}
+                {itemType === "chemicals" &&
+                  ` (${
+                    item.volume != null
+                      ? `${item.volume} mL`
+                      : item.mass != null
+                      ? `${item.mass} g`
+                      : ""
+                  })`}
               </Link>
               <div className="actions">
-                <Link to={`/${itemType}/${g._id}/edit`}>Edit</Link>
-                <button onClick={() => deleteItem(g._id, itemType)}>
+                <Link to={`/${itemType}/${item._id}/edit`}>Edit</Link>
+                <button onClick={() => deleteItem(item._id, itemType)}>
                   Delete
                 </button>
               </div>

--- a/client/src/pages/chemicals/Chemical.scss
+++ b/client/src/pages/chemicals/Chemical.scss
@@ -1,0 +1,89 @@
+.chemical-form {
+  display: flex;
+  flex-direction: column;
+  max-width: 400px;
+  margin: 0 auto;
+  gap: 0.75rem;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 500;
+  }
+
+  input,
+  textarea {
+    padding: 0.5rem;
+    font-size: 1rem;
+  }
+
+  button {
+    align-self: flex-start;
+    padding: 0.5rem 1rem;
+    background-color: #1565c0;
+    color: #ffffff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+}
+
+.chemicals-list {
+  list-style: none;
+  padding: 0;
+  max-width: 600px;
+  margin: 1rem 0;
+
+  li {
+    background: #ffffff;
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.5rem;
+    border-radius: 4px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    a {
+      color: #0b3d91;
+      text-decoration: none;
+    }
+
+    .actions {
+      display: flex;
+      gap: 0.5rem;
+
+      a,
+      button {
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        text-decoration: none;
+      }
+
+      button {
+        background-color: #1565c0;
+        color: #ffffff;
+        border: none;
+        cursor: pointer;
+      }
+    }
+  }
+}
+
+.chemical-detail {
+  max-width: 400px;
+  margin: 0 auto;
+
+  .actions {
+    margin-top: 1rem;
+    display: flex;
+    gap: 0.5rem;
+
+    a {
+      color: #1565c0;
+      text-decoration: none;
+      padding: 0.25rem 0.5rem;
+      border: 1px solid #1565c0;
+      border-radius: 4px;
+    }
+  }
+}

--- a/client/src/pages/chemicals/ChemicalDetail.jsx
+++ b/client/src/pages/chemicals/ChemicalDetail.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import CompoundDetails from "../../components/CompoundDetails";
+import "./Chemical.scss";
+
+const API_URL = "/api/chemicals";
+const PUBCHEM = "https://pubchem.ncbi.nlm.nih.gov/rest/pug";
+
+export default function ChemicalDetail() {
+  const { id } = useParams();
+  const [item, setItem] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [compound, setCompound] = useState(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/${id}`)
+      .then(res => res.json())
+      .then(data => {
+        setItem(data);
+        setLoading(false);
+        if (data?.name) {
+          fetch(
+            `${PUBCHEM}/compound/name/${encodeURIComponent(data.name)}/JSON`
+          )
+            .then(res => (res.ok ? res.json() : Promise.reject()))
+            .then(pc => setCompound(pc?.PC_Compounds?.[0]))
+            .catch(() => {});
+        }
+      })
+      .catch(() => setLoading(false));
+  }, [id]);
+
+  if (loading) return <p>Loading...</p>;
+  if (!item) return <p>Chemical not found.</p>;
+
+  return (
+    <div className="chemical-detail">
+      <h2>{item.name}</h2>
+      {item.volume != null && <p>Volume: {item.volume} mL</p>}
+      {item.mass != null && <p>Mass: {item.mass} g</p>}
+      {item.notes && <p>Notes: {item.notes}</p>}
+      {compound && <CompoundDetails compound={compound} />}
+      <div className="actions">
+        <Link to={`/chemicals/${id}/edit`}>Edit</Link>
+        <Link to="/inventory?type=chemicals">Back to list</Link>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/chemicals/CreateChemical.jsx
+++ b/client/src/pages/chemicals/CreateChemical.jsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "./Chemical.scss";
+
+const API_URL = "/api/chemicals";
+
+export default function CreateChemical() {
+  const [name, setName] = useState("");
+  const [volume, setVolume] = useState("");
+  const [mass, setMass] = useState("");
+  const [notes, setNotes] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    await fetch(API_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name,
+        volume: volume !== "" ? Number(volume) : undefined,
+        mass: mass !== "" ? Number(mass) : undefined,
+        notes,
+      }),
+    });
+    navigate("/inventory?type=chemicals");
+  };
+
+  return (
+    <div>
+      <h2>Add Chemical</h2>
+      <form className="chemical-form" onSubmit={handleSubmit}>
+        <label>
+          Name
+          <input value={name} onChange={e => setName(e.target.value)} />
+        </label>
+        <label>
+          Volume (mL)
+          <input
+            type="number"
+            value={volume}
+            onChange={e => setVolume(e.target.value)}
+          />
+        </label>
+        <label>
+          Mass (g)
+          <input
+            type="number"
+            value={mass}
+            onChange={e => setMass(e.target.value)}
+          />
+        </label>
+        <label>
+          Notes
+          <textarea value={notes} onChange={e => setNotes(e.target.value)} />
+        </label>
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/pages/chemicals/EditChemical.jsx
+++ b/client/src/pages/chemicals/EditChemical.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import "./Chemical.scss";
+
+const API_URL = "/api/chemicals";
+
+export default function EditChemical() {
+  const { id } = useParams();
+  const [name, setName] = useState("");
+  const [volume, setVolume] = useState("");
+  const [mass, setMass] = useState("");
+  const [notes, setNotes] = useState("");
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetch(`${API_URL}/${id}`)
+      .then(res => res.json())
+      .then(data => {
+        setName(data.name || "");
+        setVolume(data.volume ?? "");
+        setMass(data.mass ?? "");
+        setNotes(data.notes || "");
+      });
+  }, [id]);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    await fetch(`${API_URL}/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name,
+        volume: volume !== "" ? Number(volume) : undefined,
+        mass: mass !== "" ? Number(mass) : undefined,
+        notes,
+      }),
+    });
+    navigate(`/chemicals/${id}`);
+  };
+
+  return (
+    <div>
+      <h2>Edit Chemical</h2>
+      <form className="chemical-form" onSubmit={handleSubmit}>
+        <label>
+          Name
+          <input value={name} onChange={e => setName(e.target.value)} />
+        </label>
+        <label>
+          Volume (mL)
+          <input
+            type="number"
+            value={volume}
+            onChange={e => setVolume(e.target.value)}
+          />
+        </label>
+        <label>
+          Mass (g)
+          <input
+            type="number"
+            value={mass}
+            onChange={e => setMass(e.target.value)}
+          />
+        </label>
+        <label>
+          Notes
+          <textarea value={notes} onChange={e => setNotes(e.target.value)} />
+        </label>
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ const glasswareRouter = require("./routes/glassware");
 const ppeRouter = require("./routes/ppe");
 const equipmentRouter = require("./routes/equipment");
 const inventoryRouter = require("./routes/inventory");
+const chemicalRouter = require("./routes/chemicals");
 
 const app = express();
 const port = process.env.PORT || 5000;
@@ -24,6 +25,7 @@ app.use(express.json());
 app.use(["/api/glassware", "/glassware"], glasswareRouter);
 app.use(["/api/ppe", "/ppe"], ppeRouter);
 app.use(["/api/equipment", "/equipment"], equipmentRouter);
+app.use(["/api/chemicals", "/chemicals"], chemicalRouter);
 app.use(["/api/inventory", "/inventory"], inventoryRouter);
 
 mongoose

--- a/server/models/Chemical.js
+++ b/server/models/Chemical.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+
+const ChemicalSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  volume: { type: Number },
+  mass: { type: Number },
+  notes: { type: String },
+});
+
+ChemicalSchema.pre('validate', function (next) {
+  if (this.volume == null && this.mass == null) {
+    this.invalidate('volume', 'Either volume or mass is required');
+  }
+  next();
+});
+
+module.exports = mongoose.model('Chemical', ChemicalSchema);

--- a/server/routes/chemicals.js
+++ b/server/routes/chemicals.js
@@ -1,0 +1,74 @@
+const express = require('express');
+const Chemical = require('../models/Chemical');
+
+const router = express.Router();
+
+// Get all chemicals
+router.get('/', async (req, res) => {
+  try {
+    const all = await Chemical.find();
+    res.json(all);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Create new chemical
+router.post('/', async (req, res) => {
+  try {
+    const item = new Chemical({
+      name: req.body.name,
+      volume: req.body.volume,
+      mass: req.body.mass,
+      notes: req.body.notes,
+    });
+    const saved = await item.save();
+    res.status(201).json(saved);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Get chemical by id
+router.get('/:id', async (req, res) => {
+  try {
+    const item = await Chemical.findById(req.params.id);
+    if (!item) return res.status(404).json({ error: 'Not found' });
+    res.json(item);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Update chemical by id
+router.put('/:id', async (req, res) => {
+  try {
+    const updated = await Chemical.findByIdAndUpdate(
+      req.params.id,
+      {
+        name: req.body.name,
+        volume: req.body.volume,
+        mass: req.body.mass,
+        notes: req.body.notes,
+      },
+      { new: true, runValidators: true }
+    );
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    res.json(updated);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Delete chemical by id
+router.delete('/:id', async (req, res) => {
+  try {
+    const deleted = await Chemical.findByIdAndDelete(req.params.id);
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    res.json({ message: 'Chemical deleted' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/routes/inventory.js
+++ b/server/routes/inventory.js
@@ -2,6 +2,7 @@ const express = require('express');
 const Glassware = require('../models/Glassware');
 const PPE = require('../models/PPE');
 const Equipment = require('../models/Equipment');
+const Chemical = require('../models/Chemical');
 
 const router = express.Router();
 
@@ -11,10 +12,12 @@ router.get('/', async (req, res) => {
     const glassware = await Glassware.find().lean();
     const ppe = await PPE.find().lean();
     const equipment = await Equipment.find().lean();
+    const chemicals = await Chemical.find().lean();
     const items = [
       ...glassware.map(g => ({ ...g, type: 'glassware' })),
       ...ppe.map(p => ({ ...p, type: 'ppe' })),
       ...equipment.map(e => ({ ...e, type: 'equipment' })),
+      ...chemicals.map(c => ({ ...c, type: 'chemicals' })),
     ];
     res.json(items);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Add Mongoose model and Express routes for chemical inventory
- Integrate chemicals into inventory aggregator and server routing
- Provide React pages to create, edit, and view chemicals, including PubChem compound details

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f311ddb94832999d1383669d4c85d