### PR TITLE
feat: use RSC API for compound data

### DIFF
--- a/client/src/api/rsc.js
+++ b/client/src/api/rsc.js
@@ -1,0 +1,39 @@
+const BASE = "https://api.rsc.org/compounds/v1";
+const API_KEY = import.meta.env.VITE_RSC_KEY;
+
+async function fetchJson(url, options = {}) {
+  const res = await fetch(url, options);
+  if (!res.ok) throw new Error("No compound found");
+  return res.json();
+}
+
+export async function getCompoundByName(name) {
+  const filter = await fetchJson(`${BASE}/filter/name`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: API_KEY,
+    },
+    body: JSON.stringify({ name }),
+  });
+
+  const queryId = filter?.queryId;
+  if (!queryId) throw new Error("No compound found");
+
+  const results = await fetchJson(`${BASE}/filter/${queryId}/results`, {
+    headers: { apikey: API_KEY },
+  });
+
+  const csid = results?.results?.[0];
+  if (!csid) throw new Error("No compound found");
+
+  const details = await fetchJson(`${BASE}/records/${csid}/details`, {
+    headers: { apikey: API_KEY },
+  });
+
+  return { csid, ...details };
+}
+
+export function imageUrl(csid) {
+  return `${BASE}/records/${csid}/image`;
+}

--- a/client/src/components/CompoundDetails.jsx
+++ b/client/src/components/CompoundDetails.jsx
@@ -1,17 +1,18 @@
-// client/src/components/CompoundDetails.jsx
+import { imageUrl } from "../api/rsc";
 import "./CompoundDetails.scss";
 
-const getProp = (compound, label, name) =>
-  compound.props.find(p => p.urn.label === label && p.urn.name === name)?.value;
-
 export default function CompoundDetails({ compound }) {
-  const cid = compound?.id?.id?.cid;
-  const iupacName = getProp(compound, "IUPAC Name", "Systematic")?.sval;
-  const tradName = getProp(compound, "IUPAC Name", "Traditional")?.sval;
-  const formula = getProp(compound, "Molecular Formula")?.sval;
-  const weight = getProp(compound, "Molecular Weight")?.sval;
-  const inchi = getProp(compound, "InChI", "Standard")?.sval;
-  const smiles = getProp(compound, "SMILES", "Absolute")?.sval;
+  const {
+    csid,
+    commonName,
+    iupacName,
+    molecularFormula,
+    molecularWeight,
+    inchi,
+    smiles,
+  } = compound || {};
+
+  const name = iupacName || commonName;
 
   function Prop({ label, value }) {
     return (
@@ -25,19 +26,14 @@ export default function CompoundDetails({ compound }) {
   return (
     <div className="compound-card">
       <div className="compound-header">
-        <h2>{`${iupacName} ${
-          tradName != iupacName ? `(${tradName})` : ""
-        }`}</h2>
-        <p className="formula">{formula}</p>
+        <h2>{name}</h2>
+        {molecularFormula && <p className="formula">{molecularFormula}</p>}
       </div>
 
       <div className="compound-body">
         <div className="structure-img">
-          {cid ? (
-            <img
-              src={`https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/${cid}/PNG`}
-              alt={`Structure of ${iupacName || formula}`}
-            />
+          {csid ? (
+            <img src={imageUrl(csid)} alt={`Structure of ${name || molecularFormula}`} />
           ) : (
             <p>[No image]</p>
           )}
@@ -46,10 +42,12 @@ export default function CompoundDetails({ compound }) {
         <div className="compound-info">
           <table>
             <tbody>
-              {weight && <Prop label="Molecular Weight" value={weight} />}
+              {molecularWeight && (
+                <Prop label="Molecular Weight" value={molecularWeight} />
+              )}
               {inchi && <Prop label="InChI" value={inchi} />}
               {smiles && <Prop label="SMILES" value={smiles} />}
-              {cid && <Prop label="CID" value={cid} />}
+              {csid && <Prop label="CSID" value={csid} />}
             </tbody>
           </table>
         </div>

--- a/client/src/pages/Reference.jsx
+++ b/client/src/pages/Reference.jsx
@@ -2,29 +2,19 @@
 import { useState } from "react";
 import CompoundDetails from "../components/CompoundDetails"; // make sure path is correct
 import "./Reference.scss";
+import { getCompoundByName } from "../api/rsc";
 
 export default function Reference() {
   const [name, setName] = useState("");
   const [compound, setCompound] = useState(null);
   const [error, setError] = useState(null);
-  const pubchem = "https://pubchem.ncbi.nlm.nih.gov/rest/pug";
 
   const handleSubmit = async e => {
     e.preventDefault();
     setError(null);
     setCompound(null);
     try {
-      const response = await fetch(
-        `${pubchem}/compound/name/${encodeURIComponent(name)}/JSON`
-      );
-
-      if (!response.ok) throw new Error("No compound found");
-
-      const data = await response.json();
-      const compoundData = data?.PC_Compounds?.[0];
-
-      if (!compoundData) throw new Error("No compound found");
-
+      const compoundData = await getCompoundByName(name);
       setCompound(compoundData);
     } catch (err) {
       setError(err.message);

--- a/client/src/pages/chemicals/ChemicalDetail.jsx
+++ b/client/src/pages/chemicals/ChemicalDetail.jsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import CompoundDetails from "../../components/CompoundDetails";
 import "./Chemical.scss";
+import { getCompoundByName } from "../../api/rsc";
 
 const API_URL = "/api/chemicals";
-const PUBCHEM = "https://pubchem.ncbi.nlm.nih.gov/rest/pug";
 
 export default function ChemicalDetail() {
   const { id } = useParams();
@@ -19,11 +19,8 @@ export default function ChemicalDetail() {
         setItem(data);
         setLoading(false);
         if (data?.name) {
-          fetch(
-            `${PUBCHEM}/compound/name/${encodeURIComponent(data.name)}/JSON`
-          )
-            .then(res => (res.ok ? res.json() : Promise.reject()))
-            .then(pc => setCompound(pc?.PC_Compounds?.[0]))
+          getCompoundByName(data.name)
+            .then(setCompound)
             .catch(() => {});
         }
       })


### PR DESCRIPTION
## Summary
- replace PubChem lookups with Royal Society of Chemistry API
- display RSC-derived compound information and structure images

## Testing
- `npm --prefix client run lint`
- `npm --prefix client test` *(fails: Missing script: "test")*
- `npm --prefix server test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fca3f264c8329a5d9707cc6a32060