### PR TITLE
feat: add chemical lookup route

### DIFF
--- a/client/src/components/CompoundDetails.jsx
+++ b/client/src/components/CompoundDetails.jsx
@@ -2,16 +2,20 @@
 import "./CompoundDetails.scss";
 
 const getProp = (compound, label, name) =>
-  compound.props.find(p => p.urn.label === label && p.urn.name === name)?.value;
+  compound?.props?.find(p => p.urn.label === label && p.urn.name === name)?.value;
 
-export default function CompoundDetails({ compound }) {
+export default function CompoundDetails({ info }) {
+  const compound = info?.compound;
+  const { appearance, stability, meltingPoint, boilingPoint, smiles: canonicalSmiles } =
+    info || {};
+
   const cid = compound?.id?.id?.cid;
   const iupacName = getProp(compound, "IUPAC Name", "Systematic")?.sval;
   const tradName = getProp(compound, "IUPAC Name", "Traditional")?.sval;
   const formula = getProp(compound, "Molecular Formula")?.sval;
   const weight = getProp(compound, "Molecular Weight")?.sval;
   const inchi = getProp(compound, "InChI", "Standard")?.sval;
-  const smiles = getProp(compound, "SMILES", "Absolute")?.sval;
+  const smiles = canonicalSmiles || getProp(compound, "SMILES", "Absolute")?.sval;
 
   function Prop({ label, value }) {
     return (
@@ -50,6 +54,10 @@ export default function CompoundDetails({ compound }) {
               {inchi && <Prop label="InChI" value={inchi} />}
               {smiles && <Prop label="SMILES" value={smiles} />}
               {cid && <Prop label="CID" value={cid} />}
+              {appearance && <Prop label="Appearance" value={appearance} />}
+              {stability && <Prop label="Stability" value={stability} />}
+              {meltingPoint && <Prop label="Melting Point" value={meltingPoint} />}
+              {boilingPoint && <Prop label="Boiling Point" value={boilingPoint} />}
             </tbody>
           </table>
         </div>

--- a/client/src/pages/Reference.jsx
+++ b/client/src/pages/Reference.jsx
@@ -5,29 +5,23 @@ import "./Reference.scss";
 
 export default function Reference() {
   const [name, setName] = useState("");
-  const [compound, setCompound] = useState(null);
+  const [info, setInfo] = useState(null);
   const [error, setError] = useState(null);
-  const pubchem = "https://pubchem.ncbi.nlm.nih.gov/rest/pug";
-  // TODO: Get physical characteristics like boiling and melting point from somewhere like: https://www.chemspider.com/
-  // TODO: Get related reactions from somewhere like: https://docs.open-reaction-database.org/
+  const API_URL = "/api/chemical-info";
 
   const handleSubmit = async e => {
     e.preventDefault();
     setError(null);
-    setCompound(null);
+    setInfo(null);
     try {
       const response = await fetch(
-        `${pubchem}/compound/name/${encodeURIComponent(name)}/JSON`
+        `${API_URL}/${encodeURIComponent(name)}`
       );
 
       if (!response.ok) throw new Error("No compound found");
 
       const data = await response.json();
-      const compoundData = data?.PC_Compounds?.[0];
-
-      if (!compoundData) throw new Error("No compound found");
-
-      setCompound(compoundData);
+      setInfo(data);
     } catch (err) {
       setError(err.message);
     }
@@ -49,7 +43,7 @@ export default function Reference() {
       </form>
 
       {error && <p className="error">{error}</p>}
-      {compound && <CompoundDetails compound={compound} />}
+      {info && <CompoundDetails info={info} />}
     </div>
   );
 }

--- a/client/src/pages/chemicals/ChemicalDetail.jsx
+++ b/client/src/pages/chemicals/ChemicalDetail.jsx
@@ -4,13 +4,13 @@ import CompoundDetails from "../../components/CompoundDetails";
 import "./Chemical.scss";
 
 const API_URL = "/api/chemicals";
-const PUBCHEM = "https://pubchem.ncbi.nlm.nih.gov/rest/pug";
+const CHEM_INFO = "/api/chemical-info";
 
 export default function ChemicalDetail() {
   const { id } = useParams();
   const [item, setItem] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [compound, setCompound] = useState(null);
+  const [info, setInfo] = useState(null);
 
   useEffect(() => {
     fetch(`${API_URL}/${id}`)
@@ -19,11 +19,9 @@ export default function ChemicalDetail() {
         setItem(data);
         setLoading(false);
         if (data?.name) {
-          fetch(
-            `${PUBCHEM}/compound/name/${encodeURIComponent(data.name)}/JSON`
-          )
+          fetch(`${CHEM_INFO}/${encodeURIComponent(data.name)}`)
             .then(res => (res.ok ? res.json() : Promise.reject()))
-            .then(pc => setCompound(pc?.PC_Compounds?.[0]))
+            .then(ci => setInfo(ci))
             .catch(() => {});
         }
       })
@@ -40,7 +38,7 @@ export default function ChemicalDetail() {
       {item.mass != null && <p>Mass: {item.mass} g</p>}
       {item.concentration && <p>Concentration: {item.concentration}</p>}
       {item.notes && <p>Notes: {item.notes}</p>}
-      {compound && <CompoundDetails compound={compound} />}
+      {info && <CompoundDetails info={info} />}
       <div className="actions">
         <Link to={`/chemicals/${id}/edit`}>Edit</Link>
         <Link to="/inventory?type=chemicals">Back to list</Link>

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ const ppeRouter = require("./routes/ppe");
 const equipmentRouter = require("./routes/equipment");
 const inventoryRouter = require("./routes/inventory");
 const chemicalRouter = require("./routes/chemicals");
+const chemicalInfoRouter = require("./routes/chemicalInfo");
 const miscRouter = require("./routes/misc");
 
 const app = express();
@@ -27,6 +28,7 @@ app.use(["/api/glassware", "/glassware"], glasswareRouter);
 app.use(["/api/ppe", "/ppe"], ppeRouter);
 app.use(["/api/equipment", "/equipment"], equipmentRouter);
 app.use(["/api/chemicals", "/chemicals"], chemicalRouter);
+app.use(["/api/chemical-info", "/chemical-info"], chemicalInfoRouter);
 app.use(["/api/misc", "/misc"], miscRouter);
 app.use(["/api/inventory", "/inventory"], inventoryRouter);
 

--- a/server/routes/chemicalInfo.js
+++ b/server/routes/chemicalInfo.js
@@ -1,0 +1,66 @@
+const express = require('express');
+
+const router = express.Router();
+
+// Look up chemical details using PubChem and RSC APIs
+router.get('/:name', async (req, res) => {
+  try {
+    const name = req.params.name;
+    // Fetch SMILES from PubChem
+    const pubChemRes = await fetch(
+      `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/${encodeURIComponent(name)}/property/CanonicalSMILES/JSON`
+    );
+    if (!pubChemRes.ok)
+      return res.status(404).json({ error: 'Chemical not found in PubChem' });
+    const pubChemData = await pubChemRes.json();
+    const smiles = pubChemData?.PropertyTable?.Properties?.[0]?.CanonicalSMILES;
+    if (!smiles)
+      return res.status(404).json({ error: 'SMILES information not available' });
+
+    const apiKey = process.env.RSC_KEY;
+    if (!apiKey)
+      return res.status(500).json({ error: 'RSC API key missing' });
+
+    // Search RSC (ChemSpider) for the compound using the SMILES string
+    const filterRes = await fetch('https://api.rsc.org/compounds/v1/filter/smiles', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: apiKey,
+      },
+      body: JSON.stringify({ smiles }),
+    });
+    const filterData = await filterRes.json();
+    const queryId = filterData.queryId;
+
+    // Retrieve the first result identifier
+    const resultRes = await fetch(
+      `https://api.rsc.org/compounds/v1/filter/${queryId}/results`
+    );
+    const resultData = await resultRes.json();
+    const csid = resultData?.results?.[0];
+    if (!csid)
+      return res.status(404).json({ error: 'RSC data not found for SMILES' });
+
+    // Request details for the compound
+    const detailRes = await fetch(
+      `https://api.rsc.org/compounds/v1/records/${csid}/details?fields=Stability,MeltingPoint,BoilingPoint,Appearance`,
+      {
+        headers: { apikey: apiKey },
+      }
+    );
+    const detailData = await detailRes.json();
+
+    res.json({
+      smiles,
+      appearance: detailData.appearance,
+      stability: detailData.stability,
+      meltingPoint: detailData.meltingPoint,
+      boilingPoint: detailData.boilingPoint,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add `/chemical-info` API route to query PubChem for SMILES and enrich with RSC data
- expose new route in backend server

## Testing
- `npm test --prefix server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688fd17b0a3c83298788e38f238ccd1e