### PR TITLE
feat: backend compound lookup

### DIFF
--- a/client/src/pages/Reference.jsx
+++ b/client/src/pages/Reference.jsx
@@ -7,7 +7,7 @@ export default function Reference() {
   const [name, setName] = useState("");
   const [compound, setCompound] = useState(null);
   const [error, setError] = useState(null);
-  const pubchem = "https://pubchem.ncbi.nlm.nih.gov/rest/pug";
+  const lookupUrl = "/api/chemicals/lookup";
   // TODO: Get physical characteristics like boiling and melting point from somewhere like: https://www.chemspider.com/
   // TODO: Get related reactions from somewhere like: https://docs.open-reaction-database.org/
 
@@ -17,16 +17,12 @@ export default function Reference() {
     setCompound(null);
     try {
       const response = await fetch(
-        `${pubchem}/compound/name/${encodeURIComponent(name)}/JSON`
+        `${lookupUrl}/${encodeURIComponent(name)}`
       );
 
       if (!response.ok) throw new Error("No compound found");
 
-      const data = await response.json();
-      const compoundData = data?.PC_Compounds?.[0];
-
-      if (!compoundData) throw new Error("No compound found");
-
+      const compoundData = await response.json();
       setCompound(compoundData);
     } catch (err) {
       setError(err.message);

--- a/client/src/pages/chemicals/ChemicalDetail.jsx
+++ b/client/src/pages/chemicals/ChemicalDetail.jsx
@@ -4,7 +4,7 @@ import CompoundDetails from "../../components/CompoundDetails";
 import "./Chemical.scss";
 
 const API_URL = "/api/chemicals";
-const PUBCHEM = "https://pubchem.ncbi.nlm.nih.gov/rest/pug";
+const LOOKUP_URL = "/api/chemicals/lookup";
 
 export default function ChemicalDetail() {
   const { id } = useParams();
@@ -19,11 +19,9 @@ export default function ChemicalDetail() {
         setItem(data);
         setLoading(false);
         if (data?.name) {
-          fetch(
-            `${PUBCHEM}/compound/name/${encodeURIComponent(data.name)}/JSON`
-          )
+          fetch(`${LOOKUP_URL}/${encodeURIComponent(data.name)}`)
             .then(res => (res.ok ? res.json() : Promise.reject()))
-            .then(pc => setCompound(pc?.PC_Compounds?.[0]))
+            .then(pc => setCompound(pc))
             .catch(() => {});
         }
       })


### PR DESCRIPTION
## Summary
- add backend route to fetch PubChem compound data
- wire Reference and ChemicalDetail pages to backend
- query RSC API with SMILES data, poll for results, and log the record data

## Testing
- `npm --prefix client run lint`
- `npm --prefix server test` *(fails: "Error: no test specified")*


------
https://chatgpt.com/codex/tasks/task_e_688fd504249c8329afb5312bf31b1ebc