### PR TITLE
Requery RSC compound data

### DIFF
--- a/server/routes/chemicals.js
+++ b/server/routes/chemicals.js
@@ -81,9 +81,11 @@ router.get("/lookup/:name", async (req, res) => {
             console.log("RSC results not JSON:", rscIdsText);
           }
           if (Array.isArray(rscIds?.results) && rscIds.results.length) {
+            const fields =
+              "nominalMass,CommonName,formula,InChI,InChIkey,smiles";
             const recordPromises = rscIds.results.map(id =>
               fetch(
-                `https://api.rsc.org/compounds/v1/records/${id}/details`,
+                `https://api.rsc.org/compounds/v1/records/${id}/details?fields=${fields}`,
                 {
                   headers: {
                     apikey: process.env.RSC_KEY,

--- a/server/routes/chemicals.js
+++ b/server/routes/chemicals.js
@@ -63,7 +63,23 @@ router.get("/lookup/:name", async (req, res) => {
           }
         );
         const rscData = await rscResponse.json();
-        console.log("RSC response:", rscData);
+        if (rscData?.queryId) {
+          const rscResultsResponse = await fetch(
+            `https://api.rsc.org/compounds/v1/records/${rscData.queryId}`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                apikey: process.env.RSC_KEY,
+              },
+              body: JSON.stringify({}),
+            }
+          );
+          const rscResults = await rscResultsResponse.json();
+          console.log("RSC data:", rscResults);
+        } else {
+          console.log("RSC response:", rscData);
+        }
       } catch (e) {
         console.error("RSC lookup failed:", e);
       }

--- a/server/routes/chemicals.js
+++ b/server/routes/chemicals.js
@@ -65,14 +65,12 @@ router.get("/lookup/:name", async (req, res) => {
         const rscData = await rscResponse.json();
         if (rscData?.queryId) {
           const rscIdsResponse = await fetch(
-            `https://api.rsc.org/compounds/v1/filter/${rscData.queryId}/results`,
+            `https://api.rsc.org/compounds/v1/filter/${rscData.queryId}/results?start=0&count=10`,
             {
-              method: "POST",
               headers: {
-                "Content-Type": "application/json",
                 apikey: process.env.RSC_KEY,
+                Accept: "application/json",
               },
-              body: JSON.stringify({ start: 0, count: 10 }),
             }
           );
           const rscIdsText = await rscIdsResponse.text();
@@ -84,14 +82,15 @@ router.get("/lookup/:name", async (req, res) => {
           }
           if (Array.isArray(rscIds?.results) && rscIds.results.length) {
             const recordPromises = rscIds.results.map(id =>
-              fetch(`https://api.rsc.org/compounds/v1/records/${id}`, {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                  apikey: process.env.RSC_KEY,
-                },
-                body: JSON.stringify({}),
-              }).then(async r => {
+              fetch(
+                `https://api.rsc.org/compounds/v1/records/${id}/details`,
+                {
+                  headers: {
+                    apikey: process.env.RSC_KEY,
+                    Accept: "application/json",
+                  },
+                }
+              ).then(async r => {
                 const text = await r.text();
                 try {
                   return JSON.parse(text);

--- a/server/routes/chemicals.js
+++ b/server/routes/chemicals.js
@@ -82,7 +82,7 @@ router.get("/lookup/:name", async (req, res) => {
           }
           if (Array.isArray(rscIds?.results) && rscIds.results.length) {
             const fields =
-              "nominalMass,CommonName,formula,InChI,InChIkey,smiles";
+              "NominalMass,CommonName,Formula,InChI,InChIKey,SMILES";
             const recordPromises = rscIds.results.map(id =>
               fetch(
                 `https://api.rsc.org/compounds/v1/records/${id}/details?fields=${fields}`,


### PR DESCRIPTION
## Summary
- Requery RSC compounds API after SMILES filter to fetch actual compound records and log the results.

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688fdc4fb7d083299ed79df7daec8806